### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/api/capture.js
+++ b/api/capture.js
@@ -4,7 +4,7 @@ var crypto = require('crypto');
 var async = require('async');
 var path = require('path');
 var URL = require('url');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var _ = require('lodash');
 
 var utils = require('../lib/utils');

--- a/example/index.js
+++ b/example/index.js
@@ -2,7 +2,7 @@ var URL = require('url');
 var path = require('path');
 var moment = require('moment');
 var _ = require('lodash');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var APIPath = path.join(__dirname, '../', 'index');
 var API = require(APIPath);

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "jsftp": "^1.5.3",
     "lodash": "^4.0.1",
     "moment": "^2.11.1",
-    "node-uuid": "^1.4.7",
     "promise": "^7.1.1",
-    "request": "^2.69.0"
+    "request": "^2.69.0",
+    "uuid": "^3.0.0"
   },
   "tonicExampleFilename": "example/preview.js"
 }

--- a/test/capture.js
+++ b/test/capture.js
@@ -3,7 +3,7 @@ var URL = require('url');
 var fs = require('fs');
 var path = require('path');
 var async = require('async');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var utils = require('../lib/utils');
 
 var APIPath = path.join(__dirname, '../', 'index');


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.